### PR TITLE
feat: make nginx listen on ipv6

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,6 +5,7 @@ map $http_upgrade $connection_upgrade {
 
 server {
     listen 8000;
+    listen [::]:8000;
 
     server_name _;
 


### PR DESCRIPTION
## What was changed

Added in a listen on IPv6 to the nginx configuration file.

## Why?

On some operating systems localhost resolves to both IPv3 and IPv6. 

On these systems IPv6 gets resolved first, meaning that accessing `localhost:8000` fails on these systems when attempting to hit Buggregator.

## Checklist

- Tested
    - [x] Tested manually

