### PR TITLE
chore: serve static files directly via Nginx

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -20,6 +20,11 @@ server {
     }
 
     location / {
+        root /app/frontend/dist;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    location /api {
         proxy_pass http://127.0.0.1:8082;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## What was changed

Static files for the frontend SPA are now served directly via Nginx instead of being routed through the backend project. This removes the need for any SPA-specific configuration in the backend.

## Why?

In the current version, refreshing on any frontend route other than the Home page results in a 404 response. By serving SPA routes directly with Nginx, we can handle routing at the web server level, simplifying backend configuration and improving performance.

## Checklist

- Closes #5
- Tested
    - [x] Tested manually
    - [ ] Unit tests added

